### PR TITLE
Feat/auth register login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Sports Partner
 
-אפליקציה חברתית למציאת שותפים למשחקי ספורט. משתמשים יכולים לפרסם משחקים קרובים, לחפש משחקים פתוחים ולהירשם כמשתתפים.
+A social app for finding partners for sports games. Users can post upcoming games, search for open games, and sign up as participants.
 
-## טכנולוגיות
+## Tech Stack
 
-| צד | טכנולוגיות |
-|----|-------------|
-| שרת | Node.js, Express, TypeScript, Drizzle ORM, PostgreSQL |
-| לקוח | React 18, MUI (Material-UI), Vite, TypeScript |
-| תשתית | Docker (PostgreSQL), JWT |
+| Layer  | Technologies                                          |
+| ------ | ----------------------------------------------------- |
+| Server | Node.js, Express, TypeScript, Drizzle ORM, PostgreSQL |
+| Client | React 18, MUI (Material-UI), Vite, TypeScript         |
+| Infra  | Docker (PostgreSQL), JWT                              |
 
-## מבנה הפרויקט
+## Project Structure
 
 ```
 sports-partner/
@@ -29,76 +29,73 @@ sports-partner/
 └── package.json         # Shared scripts
 ```
 
-## דרישות מקדימות
+## Prerequisites
 
 - [Node.js](https://nodejs.org/) v20+
-- [Docker](https://www.docker.com/) (להרצת PostgreSQL מקומית)
+- [Docker](https://www.docker.com/) (for running PostgreSQL locally)
 
-## התקנה
+## Installation
 
 ```bash
-# 1. שכפול הפרויקט
+# 1. Clone the project
 git clone https://github.com/Omer-Samuel-owned-colman-projects/sports-partner.git
 cd sports-partner
 
-# 2. התקנת תלויות
+# 2. Install dependencies
 npm install
 cd server && npm install && cd ..
 cd client && npm install && cd ..
 
-# 3. הגדרת משתני סביבה
+# 3. Set up environment variables
 cp server/.env.example server/.env
-# ערוך את server/.env לפי הצורך
+# Edit server/.env as needed
 ```
 
-## מסד נתונים
+## Setup
 
 ```bash
-# הפעלת PostgreSQL עם Docker
+# Start PostgreSQL with Docker
 npm run db:up
 
-# דחיפת הסכמה למסד הנתונים
-cd server && npm run db:push
-
-# זריעת נתוני ברירת מחדל (ספורטים ומגרשים)
-npm run db:seed
+# Run the pending migrations on your DB
+npm run db:migrate
 ```
 
-### סקריפטים למסד הנתונים (מתוך תיקיית server/)
+### Database Scripts (from the server/ directory)
 
-| סקריפט | תיאור |
-|---------|-------|
-| `npm run db:push` | דחיפת הסכמה ישירות למסד הנתונים (מומלץ לפיתוח) |
-| `npm run db:generate` | יצירת קובץ migration חדש |
-| `npm run db:migrate` | הרצת migrations ממתינים |
-| `npm run db:studio` | פתיחת Drizzle Studio (ממשק גרפי למסד הנתונים) |
-| `npm run db:seed` | זריעת ספורטים ומגרשים |
+| Script                | Description                                |
+| --------------------- | ------------------------------------------ |
+| `npm run db:push`     | Push schema directly to the database       |
+| `npm run db:generate` | Generate a new migration file              |
+| `npm run db:migrate`  | Run pending migrations                     |
+| `npm run db:studio`   | Open Drizzle Studio (GUI for the database) |
+| `npm run db:seed`     | Seed sports and venues                     |
 
-### סקריפטי Docker (מתוך שורש הפרויקט)
+### Docker Scripts (from the project root)
 
-| סקריפט | תיאור |
-|---------|-------|
-| `npm run db:up` | הפעלת PostgreSQL ברקע |
-| `npm run db:down` | עצירת הקונטיינר (הנתונים נשמרים) |
-| `npm run db:reset` | מחיקת הנתונים והפעלה מחדש |
+| Script             | Description                            |
+| ------------------ | -------------------------------------- |
+| `npm run db:up`    | Start PostgreSQL in the background     |
+| `npm run db:down`  | Stop the container (data is preserved) |
+| `npm run db:reset` | Delete data and restart                |
 
-## הרצה
+### Development
 
 ```bash
-# פיתוח — שרת ולקוח במקביל
+# Development — server and client in parallel
 npm run dev
 ```
 
-- **לקוח**: http://localhost:5173
-- **שרת**: http://localhost:3001
+- **Client**: http://localhost:5173
+- **Server**: http://localhost:3001
 
 ```bash
-# הרצה נפרדת
+# Run separately
 npm run dev:server
 npm run dev:client
 ```
 
-## בנייה ופרודקשן
+## Build & Production
 
 ```bash
 npm run build
@@ -107,15 +104,10 @@ npm start
 
 ## API
 
-| Method | Route | תיאור |
-|--------|-------|-------|
-| `GET` | `/api/health` | בדיקת תקינות השרת |
-
-## משתני סביבה
-
-ראה `server/.env.example`:
-
-```env
-DATABASE_URL=postgresql://postgres:password@localhost:5432/sports_partner
-PORT=3001
-```
+| Method | Route                | Description                           |
+| ------ | -------------------- | ------------------------------------- |
+| `GET`  | `/api/health`        | Server health check                   |
+| `GET`  | `/api/auth/me`       | Return the current user               |
+| `POST` | `/api/auth/register` | Create a new user                     |
+| `POST` | `/api/auth/login`    | Login with the given credentials      |
+| `POST` | `/api/auth/logout`   | Logout by clearing the current cookie |

--- a/client/index.html
+++ b/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="he" dir="rtl">
+<html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,8 @@
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^6.1.6",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.14.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -2170,6 +2171,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -3135,6 +3149,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
+      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
+      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -3237,6 +3289,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,8 @@
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^6.1.6",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.14.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,18 +1,25 @@
-import { Container, Typography, Box } from '@mui/material'
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { LoginPage } from './pages/LoginPage';
+import { RegisterPage } from './pages/RegisterPage';
+import { HomePage } from './pages/HomePage';
+import { ProtectedRoute } from './components/ProtectedRoute';
 
 function App() {
   return (
-    <Container maxWidth="md">
-      <Box sx={{ py: 4, textAlign: 'center' }}>
-        <Typography variant="h3" component="h1" gutterBottom>
-          Sports Partner
-        </Typography>
-        <Typography variant="body1" color="text.secondary">
-          Hello World
-        </Typography>
-      </Box>
-    </Container>
-  )
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute>
+            <HomePage />
+          </ProtectedRoute>
+        }
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
 }
 
-export default App
+export default App;

--- a/client/src/components/LoginForm.tsx
+++ b/client/src/components/LoginForm.tsx
@@ -1,0 +1,48 @@
+import { useState, type FormEvent } from 'react';
+import { TextField, Button, Alert, Stack } from '@mui/material';
+import { useAuth } from '../contexts/AuthContext';
+import { ApiRequestError } from '../lib/api';
+
+export function LoginForm() {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!email || !password) {
+      setError('This field is required');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await login(email, password);
+    } catch (err) {
+      if (err instanceof ApiRequestError) {
+        setError(err.message);
+      } else {
+        setError('Server error, please try again later');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack spacing={2}>
+        {error && <Alert severity="error">{error}</Alert>}
+        <TextField label="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required fullWidth />
+        <TextField label="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required fullWidth />
+        <Button type="submit" variant="contained" fullWidth disabled={isSubmitting}>
+          {isSubmitting ? 'Logging in...' : 'Login'}
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -1,0 +1,21 @@
+import { Navigate } from 'react-router-dom';
+import { CircularProgress, Box } from '@mui/material';
+import { useAuth } from '../contexts/AuthContext';
+
+export function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const { user, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/client/src/components/RegisterForm.tsx
+++ b/client/src/components/RegisterForm.tsx
@@ -1,0 +1,61 @@
+import { useState, type FormEvent } from 'react';
+import { TextField, Button, Alert, Stack } from '@mui/material';
+import { useAuth } from '../contexts/AuthContext';
+import { ApiRequestError } from '../lib/api';
+
+export function RegisterForm() {
+  const { register } = useAuth();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!name || !email || !password) {
+      setError('This field is required');
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setError('Invalid email address');
+      return;
+    }
+
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await register(name, email, password);
+    } catch (err) {
+      if (err instanceof ApiRequestError) {
+        setError(err.message);
+      } else {
+        setError('Server error, please try again later');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack spacing={2}>
+        {error && <Alert severity="error">{error}</Alert>}
+        <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} required fullWidth />
+        <TextField label="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required fullWidth />
+        <TextField label="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required fullWidth />
+        <Button type="submit" variant="contained" fullWidth disabled={isSubmitting}>
+          {isSubmitting ? 'Registering...' : 'Register'}
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { api } from '../lib/api';
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+interface AuthContextValue {
+  user: User | null;
+  isLoading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (name: string, email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    api<{ user: User }>('/api/auth/me')
+      .then(({ user }) => setUser(user))
+      .catch(() => setUser(null))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const login = useCallback(async (email: string, password: string) => {
+    const { user } = await api<{ user: User }>('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+    });
+    setUser(user);
+  }, []);
+
+  const register = useCallback(async (name: string, email: string, password: string) => {
+    const { user } = await api<{ user: User }>('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({ name, email, password }),
+    });
+    setUser(user);
+  }, []);
+
+  const logout = useCallback(async () => {
+    await api('/api/auth/logout', { method: 'POST' });
+    setUser(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, isLoading, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return context;
+}
+
+export type { User };

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,30 @@
+interface ApiError {
+  error: string;
+}
+
+export class ApiRequestError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export async function api<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...options,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const body: ApiError = await res.json().catch(() => ({ error: 'Server error, please try again later' }));
+    throw new ApiRequestError(res.status, body.error);
+  }
+
+  return res.json() as Promise<T>;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,15 +1,21 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import { ThemeProvider, CssBaseline } from '@mui/material'
-import { theme } from './theme'
-import App from './App'
-import './index.css'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import { theme } from './theme';
+import { AuthProvider } from './contexts/AuthContext';
+import App from './App';
+import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <App />
-    </ThemeProvider>
+    <BrowserRouter>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </ThemeProvider>
+    </BrowserRouter>
   </StrictMode>,
-)
+);

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,0 +1,22 @@
+import { Container, Typography, Box, Button } from '@mui/material';
+import { useAuth } from '../contexts/AuthContext';
+
+export function HomePage() {
+  const { user, logout } = useAuth();
+
+  return (
+    <Container maxWidth="md">
+      <Box sx={{ py: 4, textAlign: 'center' }}>
+        <Typography variant="h3" component="h1" gutterBottom>
+          Sports Partner
+        </Typography>
+        <Typography variant="body1" color="text.secondary" gutterBottom>
+          Hello, {user?.name}!
+        </Typography>
+        <Button variant="outlined" onClick={logout}>
+          Logout
+        </Button>
+      </Box>
+    </Container>
+  );
+}

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,0 +1,29 @@
+import { Navigate, Link as RouterLink } from 'react-router-dom';
+import { Container, Card, CardContent, Typography, Link } from '@mui/material';
+import { useAuth } from '../contexts/AuthContext';
+import { LoginForm } from '../components/LoginForm';
+
+export function LoginPage() {
+  const { user, isLoading } = useAuth();
+
+  if (!isLoading && user) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Card>
+        <CardContent sx={{ p: 4 }}>
+          <Typography variant="h4" component="h1" gutterBottom textAlign="center">
+            Login
+          </Typography>
+          <LoginForm />
+          <Typography variant="body2" textAlign="center" sx={{ mt: 2 }}>
+            Don't have an account?{' '}
+            <Link component={RouterLink} to="/register">Register</Link>
+          </Typography>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -1,0 +1,29 @@
+import { Navigate, Link as RouterLink } from 'react-router-dom';
+import { Container, Card, CardContent, Typography, Link } from '@mui/material';
+import { useAuth } from '../contexts/AuthContext';
+import { RegisterForm } from '../components/RegisterForm';
+
+export function RegisterPage() {
+  const { user, isLoading } = useAuth();
+
+  if (!isLoading && user) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Card>
+        <CardContent sx={{ p: 4 }}>
+          <Typography variant="h4" component="h1" gutterBottom textAlign="center">
+            Register
+          </Typography>
+          <RegisterForm />
+          <Typography variant="body2" textAlign="center" sx={{ mt: 2 }}>
+            Already have an account?{' '}
+            <Link component={RouterLink} to="/login">Login</Link>
+          </Typography>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -1,7 +1,7 @@
 import { createTheme } from '@mui/material/styles'
 
 export const theme = createTheme({
-  direction: 'rtl',
+  direction: 'ltr',
   palette: {
     mode: 'light',
     primary: {

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,2 +1,4 @@
 DATABASE_URL=postgresql://postgres:password@localhost:5432/sports_partner
 PORT=3001
+JWT_SECRET=change-me-to-a-random-secret
+CLIENT_ORIGIN=http://localhost:5173

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,14 +8,20 @@
       "name": "sports-partner-server",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "drizzle-orm": "^0.45.1",
         "express": "^4.21.0",
+        "jsonwebtoken": "^9.0.3",
         "pg": "^8.20.0"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
+        "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.19.15",
         "@types/pg": "^8.18.0",
         "dotenv": "^17.3.1",
@@ -883,6 +889,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -900,6 +913,16 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {
@@ -941,11 +964,29 @@
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.15",
@@ -1028,6 +1069,15 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -1050,6 +1100,12 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -1119,6 +1175,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
@@ -1817,6 +1892,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2172,6 +2256,97 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2498,6 +2673,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.2",

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,8 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
+    "predev": "npm run db:migrate",
+    "prestart": "npm run db:migrate",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
@@ -13,14 +15,20 @@
     "db:seed": "tsx src/db/seed.ts"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "drizzle-orm": "^0.45.1",
     "express": "^4.21.0",
+    "jsonwebtoken": "^9.0.3",
     "pg": "^8.20.0"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^22.19.15",
     "@types/pg": "^8.18.0",
     "dotenv": "^17.3.1",

--- a/server/src/db/migrations/0000_last_talkback.sql
+++ b/server/src/db/migrations/0000_last_talkback.sql
@@ -1,0 +1,45 @@
+CREATE TABLE "games" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"creator_id" integer NOT NULL,
+	"sport_id" integer NOT NULL,
+	"venue_id" integer NOT NULL,
+	"scheduled_at" timestamp NOT NULL,
+	"max_players" integer NOT NULL,
+	"description" text,
+	"is_open" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "participants" (
+	"game_id" integer NOT NULL,
+	"user_id" integer NOT NULL,
+	"joined_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "participants_game_id_user_id_pk" PRIMARY KEY("game_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "sports" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(100) NOT NULL,
+	CONSTRAINT "sports_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"password_hash" varchar(255) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "venues" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"city" varchar(100) NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_creator_id_users_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_sport_id_sports_id_fk" FOREIGN KEY ("sport_id") REFERENCES "public"."sports"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "games" ADD CONSTRAINT "games_venue_id_venues_id_fk" FOREIGN KEY ("venue_id") REFERENCES "public"."venues"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "participants" ADD CONSTRAINT "participants_game_id_games_id_fk" FOREIGN KEY ("game_id") REFERENCES "public"."games"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "participants" ADD CONSTRAINT "participants_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/server/src/db/migrations/meta/0000_snapshot.json
+++ b/server/src/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,311 @@
+{
+  "id": "3309cb43-f51e-4c99-a6f7-d38dcecb8445",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport_id": {
+          "name": "sport_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_players": {
+          "name": "max_players",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_open": {
+          "name": "is_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_creator_id_users_id_fk": {
+          "name": "games_creator_id_users_id_fk",
+          "tableFrom": "games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "games_sport_id_sports_id_fk": {
+          "name": "games_sport_id_sports_id_fk",
+          "tableFrom": "games",
+          "tableTo": "sports",
+          "columnsFrom": [
+            "sport_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "games_venue_id_venues_id_fk": {
+          "name": "games_venue_id_venues_id_fk",
+          "tableFrom": "games",
+          "tableTo": "venues",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_game_id_games_id_fk": {
+          "name": "participants_game_id_games_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "participants_user_id_users_id_fk": {
+          "name": "participants_user_id_users_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "participants_game_id_user_id_pk": {
+          "name": "participants_game_id_user_id_pk",
+          "columns": [
+            "game_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sports": {
+      "name": "sports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sports_name_unique": {
+          "name": "sports_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.venues": {
+      "name": "venues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1775638901981,
+      "tag": "0000_last_talkback",
+      "breakpoints": true
+    }
+  ]
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,16 +1,24 @@
 import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
+import cookieParser from 'cookie-parser';
+import { authRouter } from './routes/auth.js';
 
 const app = express();
 const PORT = process.env.PORT ?? 3001;
 
-app.use(cors());
+app.use(cors({
+  origin: process.env.CLIENT_ORIGIN ?? 'http://localhost:5173',
+  credentials: true,
+}));
 app.use(express.json());
+app.use(cookieParser());
 
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
+
+app.use('/api/auth', authRouter);
 
 app.listen(PORT, () => {
   console.log(`Server running at http://localhost:${PORT}`);

--- a/server/src/lib/jwt.ts
+++ b/server/src/lib/jwt.ts
@@ -1,0 +1,40 @@
+import jwt from 'jsonwebtoken';
+import type { CookieOptions } from 'express';
+
+function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is required');
+  }
+  return secret;
+}
+
+const JWT_SECRET = getJwtSecret();
+const JWT_EXPIRY = '7d';
+const COOKIE_NAME = 'token';
+
+export interface JwtPayload {
+  id: number;
+  email: string;
+  name: string;
+}
+
+export function signToken(payload: JwtPayload): string {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRY });
+}
+
+export function verifyToken(token: string): JwtPayload {
+  return jwt.verify(token, JWT_SECRET) as JwtPayload;
+}
+
+export function getCookieOptions(): CookieOptions {
+  return {
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+    path: '/',
+  };
+}
+
+export { COOKIE_NAME };

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,27 @@
+import type { Request, Response, NextFunction } from 'express';
+import { verifyToken, COOKIE_NAME, type JwtPayload } from '../lib/jwt.js';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: JwtPayload;
+    }
+  }
+}
+
+export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  const token = req.cookies?.[COOKIE_NAME];
+
+  if (!token) {
+    res.status(401).json({ error: 'Not authenticated' });
+    return;
+  }
+
+  try {
+    const payload = verifyToken(token);
+    req.user = payload;
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,111 @@
+import { Router, type Request, type Response } from 'express';
+import bcrypt from 'bcryptjs';
+import { eq } from 'drizzle-orm';
+import { db } from '../db/client.js';
+import { users } from '../db/schema.js';
+import { signToken, getCookieOptions, COOKIE_NAME } from '../lib/jwt.js';
+import { requireAuth } from '../middleware/auth.js';
+
+export const authRouter = Router();
+
+// POST /api/auth/register
+authRouter.post('/register', async (req: Request, res: Response) => {
+  try {
+    const { name, email, password } = req.body;
+
+    if (!name || !email || !password) {
+      res.status(400).json({ error: 'This field is required' });
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      res.status(400).json({ error: 'Invalid email address' });
+      return;
+    }
+
+    if (password.length < 6) {
+      res.status(400).json({ error: 'Password must be at least 6 characters' });
+      return;
+    }
+
+    const existing = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+
+    if (existing.length > 0) {
+      res.status(409).json({ error: 'Email is already registered' });
+      return;
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+
+    const [newUser] = await db
+      .insert(users)
+      .values({ name, email, passwordHash })
+      .returning({ id: users.id, name: users.name, email: users.email });
+
+    const token = signToken({ id: newUser.id, email: newUser.email, name: newUser.name });
+    res.cookie(COOKIE_NAME, token, getCookieOptions());
+    res.status(201).json({ user: newUser });
+  } catch (err: unknown) {
+    if (
+      typeof err === 'object' && err !== null &&
+      'code' in err && (err as { code: string }).code === '23505'
+    ) {
+      res.status(409).json({ error: 'Email is already registered' });
+      return;
+    }
+    res.status(500).json({ error: 'Server error, please try again later' });
+  }
+});
+
+// POST /api/auth/login
+authRouter.post('/login', async (req: Request, res: Response) => {
+  try {
+    const { email, password } = req.body;
+
+    if (!email || !password) {
+      res.status(400).json({ error: 'This field is required' });
+      return;
+    }
+
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, email))
+      .limit(1);
+
+    if (!user) {
+      res.status(401).json({ error: 'Invalid email or password' });
+      return;
+    }
+
+    const valid = await bcrypt.compare(password, user.passwordHash);
+
+    if (!valid) {
+      res.status(401).json({ error: 'Invalid email or password' });
+      return;
+    }
+
+    const token = signToken({ id: user.id, email: user.email, name: user.name });
+    res.cookie(COOKIE_NAME, token, getCookieOptions());
+    res.json({ user: { id: user.id, name: user.name, email: user.email } });
+  } catch {
+    res.status(500).json({ error: 'Server error, please try again later' });
+  }
+});
+
+// POST /api/auth/logout
+authRouter.post('/logout', (_req: Request, res: Response) => {
+  res.clearCookie(COOKIE_NAME, getCookieOptions());
+  res.json({ success: true });
+});
+
+// GET /api/auth/me
+authRouter.get('/me', requireAuth, (req: Request, res: Response) => {
+  const { id, name, email } = req.user!;
+  res.json({ user: { id, name, email } });
+});


### PR DESCRIPTION
## Summary
- **Server:** JWT-based auth with httpOnly cookies — register, login, logout, and session restore endpoints (`/api/auth/*`), `requireAuth` middleware, bcrypt password hashing
- **Client:** React auth context with session persistence, login/register forms with validation, protected routing via `react-router-dom`, MUI-based UI
- **Security hardening:** Fail-fast JWT_SECRET validation, configurable CORS origin, Postgres unique constraint handling for race conditions, stripped JWT metadata from `/me` response

Closes #2

## Test plan
- [x] Start DB (`npm run db:up`) and dev servers (`npm run dev`)
- [x] Visit `/` — should redirect to `/login`
- [x] Register a new user — should redirect to home page showing greeting
- [x] Click Logout — should redirect to `/login`
- [x] Login with registered credentials — should return to home page
- [x] Refresh page — session should persist (cookie-based)
- [x] Register with duplicate email — should show "Email is already registered"
- [x] Login with wrong password — should show "Invalid email or password"
- [x] Register with short password (<6 chars) — should show validation error