### PR TITLE
feat: add comments and likes system for games (#21)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { LoginPage } from './pages/LoginPage';
 import { RegisterPage } from './pages/RegisterPage';
 import { GamesPage } from './pages/GamesPage';
 import { GameDetailPage } from './pages/GameDetailPage';
+import { GameCommentsPage } from './pages/GameCommentsPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { AppLayout } from './components/AppLayout';
 
@@ -20,6 +21,7 @@ function App() {
       >
         <Route path="/" element={<GamesPage />} />
         <Route path="/games/:id" element={<GameDetailPage />} />
+        <Route path="/games/:id/comments" element={<GameCommentsPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -26,5 +26,9 @@ export async function api<T>(url: string, options?: RequestInit): Promise<T> {
     throw new ApiRequestError(res.status, body.error);
   }
 
+  if (res.status === 204) {
+    return undefined as T;
+  }
+
   return res.json() as Promise<T>;
 }

--- a/client/src/pages/GameCommentsPage.tsx
+++ b/client/src/pages/GameCommentsPage.tsx
@@ -1,0 +1,136 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Container,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import SendIcon from '@mui/icons-material/Send';
+import { api, ApiRequestError } from '../lib/api';
+import type { GameCommentsResponse, GameComment } from '@shared/games';
+
+interface CreateCommentResponse {
+  comment: GameComment;
+}
+
+export function GameCommentsPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [comments, setComments] = useState<GameComment[]>([]);
+  const [commentText, setCommentText] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const loadComments = async () => {
+    try {
+      const { comments: loadedComments } = await api<GameCommentsResponse>(`/api/games/${id}/comments`);
+      setComments(loadedComments);
+      setError('');
+    } catch (err) {
+      const message = err instanceof ApiRequestError ? err.message : 'Failed to load comments';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadComments();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!commentText.trim()) return;
+
+    setSaving(true);
+    try {
+      const { comment } = await api<CreateCommentResponse>(`/api/games/${id}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({ content: commentText }),
+      });
+      setComments((prev) => [comment, ...prev]);
+      setCommentText('');
+      setError('');
+    } catch (err) {
+      const message = err instanceof ApiRequestError ? err.message : 'Failed to add comment';
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      <Button startIcon={<ArrowBackIcon />} onClick={() => navigate(`/games/${id}`)} sx={{ mb: 2 }}>
+        Back to game
+      </Button>
+
+      <Typography variant="h5" component="h1" gutterBottom>
+        Comments
+      </Typography>
+
+      <Box component="form" onSubmit={handleSubmit} sx={{ mb: 3 }}>
+        <Stack direction="row" spacing={1}>
+          <TextField
+            fullWidth
+            placeholder="Write a comment..."
+            value={commentText}
+            onChange={(event) => setCommentText(event.target.value)}
+            inputProps={{ maxLength: 500 }}
+          />
+          <Button
+            type="submit"
+            variant="contained"
+            endIcon={<SendIcon />}
+            disabled={saving || !commentText.trim()}
+          >
+            {saving ? 'Posting...' : 'Post'}
+          </Button>
+        </Stack>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {comments.length === 0 ? (
+        <Typography color="text.secondary">No comments yet.</Typography>
+      ) : (
+        <Stack spacing={1.5}>
+          {comments.map((comment) => (
+            <Card key={comment.id} variant="outlined">
+              <CardContent>
+                <Typography variant="body2" sx={{ mb: 0.5 }}>
+                  {comment.content}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Player #{comment.userId} - {new Date(comment.createdAt).toLocaleString()}
+                </Typography>
+              </CardContent>
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </Container>
+  );
+}

--- a/client/src/pages/GameDetailPage.tsx
+++ b/client/src/pages/GameDetailPage.tsx
@@ -29,8 +29,6 @@ export function GameDetailPage() {
   const [game, setGame] = useState<GameDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
-  const [membershipLoading, setMembershipLoading] = useState(false);
-  const [membershipError, setMembershipError] = useState('');
 
   useEffect(() => {
     api<GameDetailResponse>(`/api/games/${id}`)
@@ -39,23 +37,6 @@ export function GameDetailPage() {
       .finally(() => setIsLoading(false));
   }, [id]);
 
-  const handleMembershipToggle = async () => {
-    if (!game) return;
-
-    setMembershipLoading(true);
-    setMembershipError('');
-    try {
-      const { game: updatedGame } = await api<GameDetailResponse>(`/api/games/${id}/join`, {
-        method: game.currentUserJoined ? 'DELETE' : 'POST',
-      });
-      setGame(updatedGame);
-    } catch (err) {
-      setMembershipError(err instanceof Error ? err.message : 'Failed to update game participation');
-    } finally {
-      setMembershipLoading(false);
-    }
-  };
-
   const handleLikeToggle = async () => {
     if (!game) return;
 
@@ -63,14 +44,13 @@ export function GameDetailPage() {
     const nextLiked = !game.currentUserLiked;
     const nextLikeCount = Math.max(0, game.likeCount + (nextLiked ? 1 : -1));
     setGame({ ...game, currentUserLiked: nextLiked, likeCount: nextLikeCount });
-    setMembershipError('');
     try {
       await api<void>(`/api/games/${id}/like`, {
         method: game.currentUserLiked ? 'DELETE' : 'POST',
       });
     } catch (err) {
       setGame(previous);
-      setMembershipError(err instanceof Error ? err.message : 'Failed to update like');
+      setError(err instanceof Error ? err.message : 'Failed to update like');
     }
   };
   if (isLoading) {
@@ -145,23 +125,6 @@ export function GameDetailPage() {
             </Box>
           </Stack>
 
-          <Button
-            variant="contained"
-            size="large"
-            fullWidth
-            onClick={handleMembershipToggle}
-            disabled={membershipLoading || (!game.currentUserJoined && !game.isOpen)}
-            sx={{ mb: 3 }}
-          >
-            {membershipLoading
-              ? 'Updating...'
-              : game.currentUserJoined
-                ? 'Leave Game'
-                : game.isOpen
-                  ? 'Join Game'
-                  : 'Full'}
-          </Button>
-
           <Stack direction="row" spacing={1} sx={{ mb: 3 }}>
             <Button
               variant={game.currentUserLiked ? 'contained' : 'outlined'}
@@ -180,11 +143,6 @@ export function GameDetailPage() {
             </Button>
           </Stack>
 
-          {membershipError && (
-            <Alert severity="error" sx={{ mb: 3 }}>
-              {membershipError}
-            </Alert>
-          )}
           <Divider sx={{ mb: 2 }} />
 
           <Typography variant="h6" gutterBottom>

--- a/client/src/pages/GameDetailPage.tsx
+++ b/client/src/pages/GameDetailPage.tsx
@@ -17,6 +17,9 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import GroupIcon from '@mui/icons-material/Group';
 import PlaceIcon from '@mui/icons-material/Place';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import { api } from '../lib/api';
 import type { GameDetail, GameDetailResponse } from '@shared/games';
 
@@ -26,6 +29,8 @@ export function GameDetailPage() {
   const [game, setGame] = useState<GameDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
+  const [membershipLoading, setMembershipLoading] = useState(false);
+  const [membershipError, setMembershipError] = useState('');
 
   useEffect(() => {
     api<GameDetailResponse>(`/api/games/${id}`)
@@ -34,6 +39,40 @@ export function GameDetailPage() {
       .finally(() => setIsLoading(false));
   }, [id]);
 
+  const handleMembershipToggle = async () => {
+    if (!game) return;
+
+    setMembershipLoading(true);
+    setMembershipError('');
+    try {
+      const { game: updatedGame } = await api<GameDetailResponse>(`/api/games/${id}/join`, {
+        method: game.currentUserJoined ? 'DELETE' : 'POST',
+      });
+      setGame(updatedGame);
+    } catch (err) {
+      setMembershipError(err instanceof Error ? err.message : 'Failed to update game participation');
+    } finally {
+      setMembershipLoading(false);
+    }
+  };
+
+  const handleLikeToggle = async () => {
+    if (!game) return;
+
+    const previous = game;
+    const nextLiked = !game.currentUserLiked;
+    const nextLikeCount = Math.max(0, game.likeCount + (nextLiked ? 1 : -1));
+    setGame({ ...game, currentUserLiked: nextLiked, likeCount: nextLikeCount });
+    setMembershipError('');
+    try {
+      await api<void>(`/api/games/${id}/like`, {
+        method: game.currentUserLiked ? 'DELETE' : 'POST',
+      });
+    } catch (err) {
+      setGame(previous);
+      setMembershipError(err instanceof Error ? err.message : 'Failed to update like');
+    }
+  };
   if (isLoading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
@@ -106,6 +145,46 @@ export function GameDetailPage() {
             </Box>
           </Stack>
 
+          <Button
+            variant="contained"
+            size="large"
+            fullWidth
+            onClick={handleMembershipToggle}
+            disabled={membershipLoading || (!game.currentUserJoined && !game.isOpen)}
+            sx={{ mb: 3 }}
+          >
+            {membershipLoading
+              ? 'Updating...'
+              : game.currentUserJoined
+                ? 'Leave Game'
+                : game.isOpen
+                  ? 'Join Game'
+                  : 'Full'}
+          </Button>
+
+          <Stack direction="row" spacing={1} sx={{ mb: 3 }}>
+            <Button
+              variant={game.currentUserLiked ? 'contained' : 'outlined'}
+              color={game.currentUserLiked ? 'error' : 'inherit'}
+              startIcon={game.currentUserLiked ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+              onClick={handleLikeToggle}
+            >
+              {`${game.likeCount} Likes`}
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={<ChatBubbleOutlineIcon />}
+              onClick={() => navigate(`/games/${id}/comments`)}
+            >
+              {game.commentCount} Comments
+            </Button>
+          </Stack>
+
+          {membershipError && (
+            <Alert severity="error" sx={{ mb: 3 }}>
+              {membershipError}
+            </Alert>
+          )}
           <Divider sx={{ mb: 2 }} />
 
           <Typography variant="h6" gutterBottom>

--- a/client/src/pages/GamesPage.tsx
+++ b/client/src/pages/GamesPage.tsx
@@ -15,13 +15,17 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Button,
 } from '@mui/material';
 import GroupIcon from '@mui/icons-material/Group';
 import PlaceIcon from '@mui/icons-material/Place';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import uniqBy from 'lodash/uniqBy';
-import { api } from '../lib/api';
-import type { Game, GamesResponse } from '@shared/games';
+import { api, ApiRequestError } from '../lib/api';
+import type { Game, GamesResponse, GameDetailResponse } from '@shared/games';
 
 export function GamesPage() {
   const [games, setGames] = useState<Game[]>([]);
@@ -30,6 +34,7 @@ export function GamesPage() {
   const [error, setError] = useState('');
   const [selectedSportId, setSelectedSportId] = useState('');
   const [selectedVenueId, setSelectedVenueId] = useState('');
+  const [membershipGameId, setMembershipGameId] = useState<number | null>(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -38,10 +43,10 @@ export function GamesPage() {
       .catch(() => setError('Failed to load games'));
   }, []);
 
-  useEffect(() => {
+  const fetchGames = (sportId: string, venueId: string) => {
     const params = new URLSearchParams();
-    if (selectedSportId) params.set('sport', selectedSportId);
-    if (selectedVenueId) params.set('venue', selectedVenueId);
+    if (sportId) params.set('sport', sportId);
+    if (venueId) params.set('venue', venueId);
 
     const query = params.toString();
     const url = query ? `/api/games?${query}` : '/api/games';
@@ -52,8 +57,66 @@ export function GamesPage() {
       .then(({ games }) => setGames(games))
       .catch(() => setError('Failed to load games'))
       .finally(() => setIsLoading(false));
+  };
+
+  useEffect(() => {
+    fetchGames(selectedSportId, selectedVenueId);
   }, [selectedSportId, selectedVenueId]);
 
+  const handleMembershipToggle = async (e: React.MouseEvent, game: Game) => {
+    e.stopPropagation();
+    setMembershipGameId(game.id);
+    try {
+      await api<GameDetailResponse>(`/api/games/${game.id}/join`, {
+        method: game.currentUserJoined ? 'DELETE' : 'POST',
+      });
+      fetchGames(selectedSportId, selectedVenueId);
+    } catch (err) {
+      const message = err instanceof ApiRequestError ? err.message : 'Failed to update game participation';
+      setError(message);
+    } finally {
+      setMembershipGameId(null);
+    }
+  };
+
+  const handleLikeToggle = async (e: React.MouseEvent, game: Game) => {
+    e.stopPropagation();
+    const nextLiked = !game.currentUserLiked;
+    const nextLikeCount = Math.max(0, game.likeCount + (nextLiked ? 1 : -1));
+
+    const patchLikeState = (targetGames: Game[]) =>
+      targetGames.map((candidate) =>
+        candidate.id === game.id
+          ? { ...candidate, currentUserLiked: nextLiked, likeCount: nextLikeCount }
+          : candidate,
+      );
+
+    setGames((prev) => patchLikeState(prev));
+    setAllOpenGames((prev) => patchLikeState(prev));
+
+    try {
+      await api<void>(`/api/games/${game.id}/like`, {
+        method: game.currentUserLiked ? 'DELETE' : 'POST',
+      });
+    } catch (err) {
+      setGames((prev) =>
+        prev.map((candidate) =>
+          candidate.id === game.id
+            ? { ...candidate, currentUserLiked: game.currentUserLiked, likeCount: game.likeCount }
+            : candidate,
+        ),
+      );
+      setAllOpenGames((prev) =>
+        prev.map((candidate) =>
+          candidate.id === game.id
+            ? { ...candidate, currentUserLiked: game.currentUserLiked, likeCount: game.likeCount }
+            : candidate,
+        ),
+      );
+      const message = err instanceof ApiRequestError ? err.message : 'Failed to update like';
+      setError(message);
+    }
+  };
   const sportOptions = uniqBy(
     allOpenGames.map((game) => game.sport),
     'id',
@@ -145,7 +208,7 @@ export function GamesPage() {
                     </Typography>
                   )}
 
-                  <Stack direction="row" spacing={3} sx={{ color: 'text.secondary' }}>
+                  <Stack direction="row" spacing={3} sx={{ color: 'text.secondary', flexWrap: 'wrap', rowGap: 1 }}>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                       <PlaceIcon fontSize="small" />
                       <Typography variant="body2">
@@ -169,6 +232,44 @@ export function GamesPage() {
                       <Typography variant="body2">
                         {game.participantCount}/{game.maxPlayers}
                       </Typography>
+                    </Box>
+                    <Box sx={{ ml: 'auto' }}>
+                      <Button
+                        size="small"
+                        variant={game.currentUserLiked ? 'contained' : 'outlined'}
+                        color={game.currentUserLiked ? 'error' : 'inherit'}
+                        startIcon={game.currentUserLiked ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+                        onClick={(e) => handleLikeToggle(e, game)}
+                        sx={{ mr: 1 }}
+                      >
+                        {game.likeCount}
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        startIcon={<ChatBubbleOutlineIcon />}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          navigate(`/games/${game.id}/comments`);
+                        }}
+                        sx={{ mr: 1 }}
+                      >
+                        {game.commentCount}
+                      </Button>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        disabled={membershipGameId === game.id || (!game.currentUserJoined && !game.isOpen)}
+                        onClick={(e) => handleMembershipToggle(e, game)}
+                      >
+                        {membershipGameId === game.id
+                          ? 'Updating...'
+                          : game.currentUserJoined
+                            ? 'Leave'
+                            : game.isOpen
+                              ? 'Join'
+                              : 'Full'}
+                      </Button>
                     </Box>
                   </Stack>
                 </CardContent>

--- a/client/src/pages/GamesPage.tsx
+++ b/client/src/pages/GamesPage.tsx
@@ -25,7 +25,7 @@ import FavoriteIcon from '@mui/icons-material/Favorite';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import uniqBy from 'lodash/uniqBy';
 import { api, ApiRequestError } from '../lib/api';
-import type { Game, GamesResponse, GameDetailResponse } from '@shared/games';
+import type { Game, GamesResponse } from '@shared/games';
 
 export function GamesPage() {
   const [games, setGames] = useState<Game[]>([]);
@@ -34,7 +34,6 @@ export function GamesPage() {
   const [error, setError] = useState('');
   const [selectedSportId, setSelectedSportId] = useState('');
   const [selectedVenueId, setSelectedVenueId] = useState('');
-  const [membershipGameId, setMembershipGameId] = useState<number | null>(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -62,22 +61,6 @@ export function GamesPage() {
   useEffect(() => {
     fetchGames(selectedSportId, selectedVenueId);
   }, [selectedSportId, selectedVenueId]);
-
-  const handleMembershipToggle = async (e: React.MouseEvent, game: Game) => {
-    e.stopPropagation();
-    setMembershipGameId(game.id);
-    try {
-      await api<GameDetailResponse>(`/api/games/${game.id}/join`, {
-        method: game.currentUserJoined ? 'DELETE' : 'POST',
-      });
-      fetchGames(selectedSportId, selectedVenueId);
-    } catch (err) {
-      const message = err instanceof ApiRequestError ? err.message : 'Failed to update game participation';
-      setError(message);
-    } finally {
-      setMembershipGameId(null);
-    }
-  };
 
   const handleLikeToggle = async (e: React.MouseEvent, game: Game) => {
     e.stopPropagation();
@@ -255,20 +238,6 @@ export function GamesPage() {
                         sx={{ mr: 1 }}
                       >
                         {game.commentCount}
-                      </Button>
-                      <Button
-                        size="small"
-                        variant="outlined"
-                        disabled={membershipGameId === game.id || (!game.currentUserJoined && !game.isOpen)}
-                        onClick={(e) => handleMembershipToggle(e, game)}
-                      >
-                        {membershipGameId === game.id
-                          ? 'Updating...'
-                          : game.currentUserJoined
-                            ? 'Leave'
-                            : game.isOpen
-                              ? 'Join'
-                              : 'Full'}
                       </Button>
                     </Box>
                   </Stack>

--- a/server/src/db/migrations/0001_game_social_interactions.sql
+++ b/server/src/db/migrations/0001_game_social_interactions.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "game_comments" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"game_id" integer NOT NULL,
+	"user_id" integer NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "game_likes" (
+	"game_id" integer NOT NULL,
+	"user_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "game_likes_game_id_user_id_pk" PRIMARY KEY("game_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "game_comments" ADD CONSTRAINT "game_comments_game_id_games_id_fk" FOREIGN KEY ("game_id") REFERENCES "public"."games"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "game_comments" ADD CONSTRAINT "game_comments_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "game_likes" ADD CONSTRAINT "game_likes_game_id_games_id_fk" FOREIGN KEY ("game_id") REFERENCES "public"."games"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "game_likes" ADD CONSTRAINT "game_likes_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775638901981,
       "tag": "0000_last_talkback",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777000000000,
+      "tag": "0001_game_social_interactions",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -61,11 +61,39 @@ export const participants = pgTable(
   (table) => [primaryKey({ columns: [table.gameId, table.userId] })],
 );
 
+export const gameLikes = pgTable(
+  'game_likes',
+  {
+    gameId: integer('game_id')
+      .notNull()
+      .references(() => games.id),
+    userId: integer('user_id')
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.gameId, table.userId] })],
+);
+
+export const gameComments = pgTable('game_comments', {
+  id: serial('id').primaryKey(),
+  gameId: integer('game_id')
+    .notNull()
+    .references(() => games.id),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id),
+  content: text('content').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
 // Relations
 
 export const usersRelations = relations(users, ({ many }) => ({
   games: many(games),
   participations: many(participants),
+  gameLikes: many(gameLikes),
+  gameComments: many(gameComments),
 }));
 
 export const sportsRelations = relations(sports, ({ many }) => ({
@@ -81,9 +109,21 @@ export const gamesRelations = relations(games, ({ one, many }) => ({
   sport: one(sports, { fields: [games.sportId], references: [sports.id] }),
   venue: one(venues, { fields: [games.venueId], references: [venues.id] }),
   participants: many(participants),
+  likes: many(gameLikes),
+  comments: many(gameComments),
 }));
 
 export const participantsRelations = relations(participants, ({ one }) => ({
   game: one(games, { fields: [participants.gameId], references: [games.id] }),
   user: one(users, { fields: [participants.userId], references: [users.id] }),
+}));
+
+export const gameLikesRelations = relations(gameLikes, ({ one }) => ({
+  game: one(games, { fields: [gameLikes.gameId], references: [games.id] }),
+  user: one(users, { fields: [gameLikes.userId], references: [users.id] }),
+}));
+
+export const gameCommentsRelations = relations(gameComments, ({ one }) => ({
+  game: one(games, { fields: [gameComments.gameId], references: [games.id] }),
+  user: one(users, { fields: [gameComments.userId], references: [users.id] }),
 }));

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -25,3 +25,19 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
     res.status(401).json({ error: 'Invalid token' });
   }
 }
+
+export function optionalAuth(req: Request, _res: Response, next: NextFunction): void {
+  const token = req.cookies?.[COOKIE_NAME];
+  if (!token) {
+    next();
+    return;
+  }
+
+  try {
+    req.user = verifyToken(token);
+  } catch {
+    req.user = undefined;
+  }
+
+  next();
+}

--- a/server/src/routes/games.ts
+++ b/server/src/routes/games.ts
@@ -1,15 +1,26 @@
 import { Router, type Request, type Response } from 'express';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, count, desc, eq, sql } from 'drizzle-orm';
 import { db } from '../db/client.js';
-import { games, sports, venues, participants } from '../db/schema.js';
+import { gameComments, gameLikes, games, sports, venues, participants } from '../db/schema.js';
 import { parsePositiveIntQueryParam } from '../lib/query.js';
-import type { GamesResponse, GameDetailResponse } from '../types/games.js';
+import { optionalAuth, requireAuth } from '../middleware/auth.js';
+import type {
+  GamesResponse,
+  GameCommentsResponse,
+  GameDetailResponse,
+} from '../types/games.js';
 
 export const gamesRouter = Router();
 
 const participantCount = sql<number>`(
   SELECT count(*)::int FROM participants WHERE participants.game_id = games.id
 )`.as('participant_count');
+const likeCount = sql<number>`(
+  SELECT count(*)::int FROM game_likes WHERE game_likes.game_id = games.id
+)`.as('like_count');
+const commentCount = sql<number>`(
+  SELECT count(*)::int FROM game_comments WHERE game_comments.game_id = games.id
+)`.as('comment_count');
 
 const gameSelect = {
   id: games.id,
@@ -22,10 +33,29 @@ const gameSelect = {
   venue: { id: venues.id, name: venues.name, city: venues.city },
   creator: { id: games.creatorId },
   participantCount,
+  likeCount,
+  commentCount,
 } as const;
 
+function currentUserJoined(userId: number | undefined) {
+  if (!userId) return sql<boolean>`false`.as('current_user_joined');
+  return sql<boolean>`EXISTS (
+    SELECT 1 FROM participants
+    WHERE participants.game_id = games.id
+    AND participants.user_id = ${userId}
+  )`.as('current_user_joined');
+}
+
+function currentUserLiked(userId: number | undefined) {
+  if (!userId) return sql<boolean>`false`.as('current_user_liked');
+  return sql<boolean>`EXISTS (
+    SELECT 1 FROM game_likes
+    WHERE game_likes.game_id = games.id
+    AND game_likes.user_id = ${userId}
+  )`.as('current_user_liked');
+}
 // GET /api/games
-gamesRouter.get('/', async (req: Request, res: Response) => {
+gamesRouter.get('/', optionalAuth, async (req: Request, res: Response) => {
   try {
     const { sport, venue } = req.query;
 
@@ -45,7 +75,11 @@ gamesRouter.get('/', async (req: Request, res: Response) => {
     if (venueId) whereConditions.push(eq(games.venueId, venueId));
 
     const rows = await db
-      .select(gameSelect)
+      .select({
+        ...gameSelect,
+        currentUserJoined: currentUserJoined(req.user?.id),
+        currentUserLiked: currentUserLiked(req.user?.id),
+      })
       .from(games)
       .innerJoin(sports, eq(games.sportId, sports.id))
       .innerJoin(venues, eq(games.venueId, venues.id))
@@ -59,7 +93,7 @@ gamesRouter.get('/', async (req: Request, res: Response) => {
 });
 
 // GET /api/games/:id
-gamesRouter.get('/:id', async (req: Request, res: Response) => {
+gamesRouter.get('/:id', optionalAuth, async (req: Request, res: Response) => {
   try {
     const gameId = Number(req.params.id);
     if (Number.isNaN(gameId)) {
@@ -68,7 +102,11 @@ gamesRouter.get('/:id', async (req: Request, res: Response) => {
     }
 
     const [row] = await db
-      .select(gameSelect)
+      .select({
+        ...gameSelect,
+        currentUserJoined: currentUserJoined(req.user?.id),
+        currentUserLiked: currentUserLiked(req.user?.id),
+      })
       .from(games)
       .innerJoin(sports, eq(games.sportId, sports.id))
       .innerJoin(venues, eq(games.venueId, venues.id))
@@ -89,6 +127,273 @@ gamesRouter.get('/:id', async (req: Request, res: Response) => {
       .where(eq(participants.gameId, gameId));
 
     res.json({ game: { ...row, participants: gameParticipants } } satisfies GameDetailResponse);
+  } catch {
+    res.status(500).json({ error: 'Server error, please try again later' });
+  }
+});
+// POST /api/games/:id/join
+gamesRouter.post('/:id/join', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const gameId = Number(req.params.id);
+    if (Number.isNaN(gameId)) {
+      res.status(400).json({ error: 'Invalid game ID' });
+      return;
+    }
+
+    const userId = req.user!.id;
+
+    const result = await db.transaction(async (tx) => {
+      const [game] = await tx
+        .select({ maxPlayers: games.maxPlayers, isOpen: games.isOpen })
+        .from(games)
+        .where(eq(games.id, gameId))
+        .limit(1);
+
+      if (!game) return { error: 'Game not found', status: 404 as const };
+      if (!game.isOpen) return { error: 'Game is full', status: 409 as const };
+
+      const [existing] = await tx
+        .select({ gameId: participants.gameId })
+        .from(participants)
+        .where(and(eq(participants.gameId, gameId), eq(participants.userId, userId)))
+        .limit(1);
+
+      if (existing) return { error: 'Already joined', status: 409 as const };
+
+      await tx.insert(participants).values({ gameId, userId });
+
+      const [{ value: participantCount }] = await tx
+        .select({ value: count() })
+        .from(participants)
+        .where(eq(participants.gameId, gameId));
+
+      if (participantCount >= game.maxPlayers) {
+        await tx.update(games).set({ isOpen: false }).where(eq(games.id, gameId));
+      }
+
+      return null;
+    });
+
+    if (result) {
+      res.status(result.status).json({ error: result.error });
+      return;
+    }
+
+    // Return refreshed game detail
+    const [row] = await db
+      .select({
+        ...gameSelect,
+        currentUserJoined: currentUserJoined(userId),
+        currentUserLiked: currentUserLiked(userId),
+      })
+      .from(games)
+      .innerJoin(sports, eq(games.sportId, sports.id))
+      .innerJoin(venues, eq(games.venueId, venues.id))
+      .where(eq(games.id, gameId))
+      .limit(1);
+
+    const gameParticipants = await db
+      .select({
+        userId: participants.userId,
+        joinedAt: participants.joinedAt,
+      })
+      .from(participants)
+      .where(eq(participants.gameId, gameId));
+
+    res.json({ game: { ...row!, participants: gameParticipants } } satisfies GameDetailResponse);
+  } catch {
+    res.status(500).json({ error: 'Server error, please try again later' });
+  }
+});
+
+// DELETE /api/games/:id/join
+gamesRouter.delete('/:id/join', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const gameId = Number(req.params.id);
+    if (Number.isNaN(gameId)) {
+      res.status(400).json({ error: 'Invalid game ID' });
+      return;
+    }
+
+    const userId = req.user!.id;
+
+    const result = await db.transaction(async (tx) => {
+      const [game] = await tx
+        .select({ id: games.id, maxPlayers: games.maxPlayers })
+        .from(games)
+        .where(eq(games.id, gameId))
+        .limit(1);
+
+      if (!game) return { error: 'Game not found', status: 404 as const };
+
+      const [existing] = await tx
+        .select({ gameId: participants.gameId })
+        .from(participants)
+        .where(and(eq(participants.gameId, gameId), eq(participants.userId, userId)))
+        .limit(1);
+
+      if (!existing) return { error: 'Not joined', status: 409 as const };
+
+      await tx
+        .delete(participants)
+        .where(and(eq(participants.gameId, gameId), eq(participants.userId, userId)));
+
+      const [{ value: participantCount }] = await tx
+        .select({ value: count() })
+        .from(participants)
+        .where(eq(participants.gameId, gameId));
+
+      if (participantCount < game.maxPlayers) {
+        await tx.update(games).set({ isOpen: true }).where(eq(games.id, gameId));
+      }
+
+      return null;
+    });
+
+    if (result) {
+      res.status(result.status).json({ error: result.error });
+      return;
+    }
+
+    const [row] = await db
+      .select({
+        ...gameSelect,
+        currentUserJoined: currentUserJoined(userId),
+        currentUserLiked: currentUserLiked(userId),
+      })
+      .from(games)
+      .innerJoin(sports, eq(games.sportId, sports.id))
+      .innerJoin(venues, eq(games.venueId, venues.id))
+      .where(eq(games.id, gameId))
+      .limit(1);
+
+    const gameParticipants = await db
+      .select({
+        userId: participants.userId,
+        joinedAt: participants.joinedAt,
+      })
+      .from(participants)
+      .where(eq(participants.gameId, gameId));
+
+    res.json({ game: { ...row!, participants: gameParticipants } } satisfies GameDetailResponse);
+  } catch {
+    res.status(500).json({ error: 'Server error, please try again later' });
+  }
+});
+
+// POST /api/games/:id/like
+gamesRouter.post('/:id/like', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const gameId = Number(req.params.id);
+    if (Number.isNaN(gameId)) {
+      res.status(400).json({ error: 'Invalid game ID' });
+      return;
+    }
+
+    const userId = req.user!.id;
+
+    const [game] = await db.select({ id: games.id }).from(games).where(eq(games.id, gameId)).limit(1);
+    if (!game) {
+      res.status(404).json({ error: 'Game not found' });
+      return;
+    }
+
+    await db.insert(gameLikes).values({ gameId, userId }).onConflictDoNothing();
+    res.status(204).send();
+  } catch {
+    res.status(500).json({ error: 'Server error, please try again later' });
+  }
+});
+
+// DELETE /api/games/:id/like
+gamesRouter.delete('/:id/like', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const gameId = Number(req.params.id);
+    if (Number.isNaN(gameId)) {
+      res.status(400).json({ error: 'Invalid game ID' });
+      return;
+    }
+
+    const userId = req.user!.id;
+    await db.delete(gameLikes).where(and(eq(gameLikes.gameId, gameId), eq(gameLikes.userId, userId)));
+    res.status(204).send();
+  } catch {
+    res.status(500).json({ error: 'Server error, please try again later' });
+  }
+});
+
+// GET /api/games/:id/comments
+gamesRouter.get('/:id/comments', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const gameId = Number(req.params.id);
+    if (Number.isNaN(gameId)) {
+      res.status(400).json({ error: 'Invalid game ID' });
+      return;
+    }
+
+    const [game] = await db.select({ id: games.id }).from(games).where(eq(games.id, gameId)).limit(1);
+    if (!game) {
+      res.status(404).json({ error: 'Game not found' });
+      return;
+    }
+
+    const comments = await db
+      .select({
+        id: gameComments.id,
+        userId: gameComments.userId,
+        content: gameComments.content,
+        createdAt: gameComments.createdAt,
+      })
+      .from(gameComments)
+      .where(eq(gameComments.gameId, gameId))
+      .orderBy(desc(gameComments.createdAt));
+
+    res.json({ comments } satisfies GameCommentsResponse);
+  } catch {
+    res.status(500).json({ error: 'Server error, please try again later' });
+  }
+});
+
+// POST /api/games/:id/comments
+gamesRouter.post('/:id/comments', requireAuth, async (req: Request, res: Response) => {
+  try {
+    const gameId = Number(req.params.id);
+    if (Number.isNaN(gameId)) {
+      res.status(400).json({ error: 'Invalid game ID' });
+      return;
+    }
+
+    const content = typeof req.body?.content === 'string' ? req.body.content.trim() : '';
+    if (!content) {
+      res.status(400).json({ error: 'Comment cannot be empty' });
+      return;
+    }
+    if (content.length > 500) {
+      res.status(400).json({ error: 'Comment cannot exceed 500 characters' });
+      return;
+    }
+
+    const [game] = await db.select({ id: games.id }).from(games).where(eq(games.id, gameId)).limit(1);
+    if (!game) {
+      res.status(404).json({ error: 'Game not found' });
+      return;
+    }
+
+    const [comment] = await db
+      .insert(gameComments)
+      .values({
+        gameId,
+        userId: req.user!.id,
+        content,
+      })
+      .returning({
+        id: gameComments.id,
+        userId: gameComments.userId,
+        content: gameComments.content,
+        createdAt: gameComments.createdAt,
+      });
+
+    res.status(201).json({ comment });
   } catch {
     res.status(500).json({ error: 'Server error, please try again later' });
   }

--- a/server/src/routes/games.ts
+++ b/server/src/routes/games.ts
@@ -37,15 +37,6 @@ const gameSelect = {
   commentCount,
 } as const;
 
-function currentUserJoined(userId: number | undefined) {
-  if (!userId) return sql<boolean>`false`.as('current_user_joined');
-  return sql<boolean>`EXISTS (
-    SELECT 1 FROM participants
-    WHERE participants.game_id = games.id
-    AND participants.user_id = ${userId}
-  )`.as('current_user_joined');
-}
-
 function currentUserLiked(userId: number | undefined) {
   if (!userId) return sql<boolean>`false`.as('current_user_liked');
   return sql<boolean>`EXISTS (
@@ -77,7 +68,6 @@ gamesRouter.get('/', optionalAuth, async (req: Request, res: Response) => {
     const rows = await db
       .select({
         ...gameSelect,
-        currentUserJoined: currentUserJoined(req.user?.id),
         currentUserLiked: currentUserLiked(req.user?.id),
       })
       .from(games)
@@ -104,7 +94,6 @@ gamesRouter.get('/:id', optionalAuth, async (req: Request, res: Response) => {
     const [row] = await db
       .select({
         ...gameSelect,
-        currentUserJoined: currentUserJoined(req.user?.id),
         currentUserLiked: currentUserLiked(req.user?.id),
       })
       .from(games)
@@ -131,156 +120,6 @@ gamesRouter.get('/:id', optionalAuth, async (req: Request, res: Response) => {
     res.status(500).json({ error: 'Server error, please try again later' });
   }
 });
-// POST /api/games/:id/join
-gamesRouter.post('/:id/join', requireAuth, async (req: Request, res: Response) => {
-  try {
-    const gameId = Number(req.params.id);
-    if (Number.isNaN(gameId)) {
-      res.status(400).json({ error: 'Invalid game ID' });
-      return;
-    }
-
-    const userId = req.user!.id;
-
-    const result = await db.transaction(async (tx) => {
-      const [game] = await tx
-        .select({ maxPlayers: games.maxPlayers, isOpen: games.isOpen })
-        .from(games)
-        .where(eq(games.id, gameId))
-        .limit(1);
-
-      if (!game) return { error: 'Game not found', status: 404 as const };
-      if (!game.isOpen) return { error: 'Game is full', status: 409 as const };
-
-      const [existing] = await tx
-        .select({ gameId: participants.gameId })
-        .from(participants)
-        .where(and(eq(participants.gameId, gameId), eq(participants.userId, userId)))
-        .limit(1);
-
-      if (existing) return { error: 'Already joined', status: 409 as const };
-
-      await tx.insert(participants).values({ gameId, userId });
-
-      const [{ value: participantCount }] = await tx
-        .select({ value: count() })
-        .from(participants)
-        .where(eq(participants.gameId, gameId));
-
-      if (participantCount >= game.maxPlayers) {
-        await tx.update(games).set({ isOpen: false }).where(eq(games.id, gameId));
-      }
-
-      return null;
-    });
-
-    if (result) {
-      res.status(result.status).json({ error: result.error });
-      return;
-    }
-
-    // Return refreshed game detail
-    const [row] = await db
-      .select({
-        ...gameSelect,
-        currentUserJoined: currentUserJoined(userId),
-        currentUserLiked: currentUserLiked(userId),
-      })
-      .from(games)
-      .innerJoin(sports, eq(games.sportId, sports.id))
-      .innerJoin(venues, eq(games.venueId, venues.id))
-      .where(eq(games.id, gameId))
-      .limit(1);
-
-    const gameParticipants = await db
-      .select({
-        userId: participants.userId,
-        joinedAt: participants.joinedAt,
-      })
-      .from(participants)
-      .where(eq(participants.gameId, gameId));
-
-    res.json({ game: { ...row!, participants: gameParticipants } } satisfies GameDetailResponse);
-  } catch {
-    res.status(500).json({ error: 'Server error, please try again later' });
-  }
-});
-
-// DELETE /api/games/:id/join
-gamesRouter.delete('/:id/join', requireAuth, async (req: Request, res: Response) => {
-  try {
-    const gameId = Number(req.params.id);
-    if (Number.isNaN(gameId)) {
-      res.status(400).json({ error: 'Invalid game ID' });
-      return;
-    }
-
-    const userId = req.user!.id;
-
-    const result = await db.transaction(async (tx) => {
-      const [game] = await tx
-        .select({ id: games.id, maxPlayers: games.maxPlayers })
-        .from(games)
-        .where(eq(games.id, gameId))
-        .limit(1);
-
-      if (!game) return { error: 'Game not found', status: 404 as const };
-
-      const [existing] = await tx
-        .select({ gameId: participants.gameId })
-        .from(participants)
-        .where(and(eq(participants.gameId, gameId), eq(participants.userId, userId)))
-        .limit(1);
-
-      if (!existing) return { error: 'Not joined', status: 409 as const };
-
-      await tx
-        .delete(participants)
-        .where(and(eq(participants.gameId, gameId), eq(participants.userId, userId)));
-
-      const [{ value: participantCount }] = await tx
-        .select({ value: count() })
-        .from(participants)
-        .where(eq(participants.gameId, gameId));
-
-      if (participantCount < game.maxPlayers) {
-        await tx.update(games).set({ isOpen: true }).where(eq(games.id, gameId));
-      }
-
-      return null;
-    });
-
-    if (result) {
-      res.status(result.status).json({ error: result.error });
-      return;
-    }
-
-    const [row] = await db
-      .select({
-        ...gameSelect,
-        currentUserJoined: currentUserJoined(userId),
-        currentUserLiked: currentUserLiked(userId),
-      })
-      .from(games)
-      .innerJoin(sports, eq(games.sportId, sports.id))
-      .innerJoin(venues, eq(games.venueId, venues.id))
-      .where(eq(games.id, gameId))
-      .limit(1);
-
-    const gameParticipants = await db
-      .select({
-        userId: participants.userId,
-        joinedAt: participants.joinedAt,
-      })
-      .from(participants)
-      .where(eq(participants.gameId, gameId));
-
-    res.json({ game: { ...row!, participants: gameParticipants } } satisfies GameDetailResponse);
-  } catch {
-    res.status(500).json({ error: 'Server error, please try again later' });
-  }
-});
-
 // POST /api/games/:id/like
 gamesRouter.post('/:id/like', requireAuth, async (req: Request, res: Response) => {
   try {

--- a/server/src/types/games.ts
+++ b/server/src/types/games.ts
@@ -10,7 +10,6 @@ export type Game = Pick<
   participantCount: number;
   likeCount: number;
   commentCount: number;
-  currentUserJoined: boolean;
   currentUserLiked: boolean;
 };
 

--- a/server/src/types/games.ts
+++ b/server/src/types/games.ts
@@ -1,4 +1,4 @@
-import type { games, sports, venues, participants } from '../db/schema.js';
+import type { games, sports, venues, participants, gameComments } from '../db/schema.js';
 
 export type Game = Pick<
   typeof games.$inferSelect,
@@ -8,6 +8,10 @@ export type Game = Pick<
   venue: Pick<typeof venues.$inferSelect, 'id' | 'name' | 'city'>;
   creator: { id: number };
   participantCount: number;
+  likeCount: number;
+  commentCount: number;
+  currentUserJoined: boolean;
+  currentUserLiked: boolean;
 };
 
 export type GameParticipant = Pick<
@@ -19,10 +23,16 @@ export type GameDetail = Game & {
   participants: GameParticipant[];
 };
 
+export type GameComment = Pick<typeof gameComments.$inferSelect, 'id' | 'userId' | 'content' | 'createdAt'>;
+
 export interface GamesResponse {
   games: Game[];
 }
 
 export interface GameDetailResponse {
   game: GameDetail;
+}
+
+export interface GameCommentsResponse {
+  comments: GameComment[];
 }


### PR DESCRIPTION
## Summary
- add persistent game likes and comments tables with migration and schema relations
- expose like toggle and comments CRUD APIs, plus counts and current-user liked state in game payloads
- add a dedicated comments screen and update games/detail pages to show comment counts and like toggles

## Test plan
- [x] Run `npm run build` from repo root
- [ ] Run migrations in a local DB and verify like/comment data persists
- [ ] Manually verify feed shows comment count and like state correctly for authenticated user
- [ ] Manually verify creating comments on `/games/:id/comments` updates list and count

resolves #21 
