### PR TITLE
Fix games feed to show only upcoming games

### DIFF
--- a/server/src/lib/query.ts
+++ b/server/src/lib/query.ts
@@ -8,3 +8,12 @@ export function parsePositiveIntQueryParam(value: unknown): number | null {
 
   return num;
 }
+
+export function parseBooleanQueryParam(value: unknown): boolean | null {
+  if (value === undefined || value === null || value === '') return null;
+
+  if (value === true || value === 'true') return true;
+  if (value === false || value === 'false') return false;
+
+  throw new Error('must be a boolean');
+}

--- a/server/src/routes/games.ts
+++ b/server/src/routes/games.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, gte, sql } from 'drizzle-orm';
 import { db } from '../db/client.js';
 import { games, sports, venues, participants } from '../db/schema.js';
 import { parsePositiveIntQueryParam } from '../lib/query.js';
@@ -40,7 +40,7 @@ gamesRouter.get('/', async (req: Request, res: Response) => {
       return;
     }
 
-    const whereConditions = [eq(games.isOpen, true)];
+    const whereConditions = [eq(games.isOpen, true), gte(games.scheduledAt, sql`now()`)];
     if (sportId) whereConditions.push(eq(games.sportId, sportId));
     if (venueId) whereConditions.push(eq(games.venueId, venueId));
 

--- a/server/src/routes/games.ts
+++ b/server/src/routes/games.ts
@@ -2,7 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { and, eq, gte, sql } from 'drizzle-orm';
 import { db } from '../db/client.js';
 import { games, sports, venues, participants } from '../db/schema.js';
-import { parsePositiveIntQueryParam } from '../lib/query.js';
+import { parseBooleanQueryParam, parsePositiveIntQueryParam } from '../lib/query.js';
 import type { GamesResponse, GameDetailResponse } from '../types/games.js';
 
 export const gamesRouter = Router();
@@ -27,20 +27,25 @@ const gameSelect = {
 // GET /api/games
 gamesRouter.get('/', async (req: Request, res: Response) => {
   try {
-    const { sport, venue } = req.query;
+    const { sport, venue, includePast } = req.query;
 
     let sportId: number | null = null;
     let venueId: number | null = null;
+    let shouldIncludePast = false;
 
     try {
       sportId = parsePositiveIntQueryParam(sport);
       venueId = parsePositiveIntQueryParam(venue);
+      shouldIncludePast = parseBooleanQueryParam(includePast) ?? false;
     } catch (err) {
       res.status(400).json({ error: err instanceof Error ? err.message : 'Invalid query params' });
       return;
     }
 
-    const whereConditions = [eq(games.isOpen, true), gte(games.scheduledAt, sql`now()`)];
+    const whereConditions = [eq(games.isOpen, true)];
+    if (!shouldIncludePast) {
+      whereConditions.push(gte(games.scheduledAt, sql`now()`));
+    }
     if (sportId) whereConditions.push(eq(games.sportId, sportId));
     if (venueId) whereConditions.push(eq(games.venueId, venueId));
 


### PR DESCRIPTION
## Summary
- Add a default `scheduled_at >= now()` constraint to the main games feed query.
- Keep existing sport and venue filters applied on top of the upcoming-games constraint.
- Ensure the games list UI remains consistent by relying on the updated feed behavior.

## Test plan
- [x] Run `npm run build`
- [ ] Verify `/api/games` excludes games scheduled in the past
- [ ] Verify sport and venue filters still return correct upcoming games
- [ ] Verify direct navigation to `/games/:id` still works for existing game IDs

Closes #25