### PR TITLE
feat: add Google OAuth and refresh token support

### DIFF
--- a/client/src/components/GoogleLoginButton.tsx
+++ b/client/src/components/GoogleLoginButton.tsx
@@ -1,0 +1,19 @@
+import { Button } from '@mui/material';
+import GoogleIcon from '@mui/icons-material/Google';
+
+export function GoogleLoginButton() {
+  const handleClick = () => {
+    window.location.href = '/api/auth/google';
+  };
+
+  return (
+    <Button
+      variant="outlined"
+      fullWidth
+      startIcon={<GoogleIcon />}
+      onClick={handleClick}
+    >
+      Continue with Google
+    </Button>
+  );
+}

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -19,12 +19,30 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+async function fetchWithRefresh<T>(url: string, options?: RequestInit): Promise<T> {
+  try {
+    return await api<T>(url, options);
+  } catch (err) {
+    if (err instanceof Error && 'status' in err && (err as { status: number }).status === 401) {
+      // Try refreshing the access token
+      const refreshRes = await fetch('/api/auth/refresh', {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (refreshRes.ok) {
+        return await api<T>(url, options);
+      }
+    }
+    throw err;
+  }
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    api<{ user: User }>('/api/auth/me')
+    fetchWithRefresh<{ user: User }>('/api/auth/me')
       .then(({ user }) => setUser(user))
       .catch(() => setUser(null))
       .finally(() => setIsLoading(false));

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,10 +1,13 @@
-import { Navigate, Link as RouterLink } from 'react-router-dom';
-import { Container, Card, CardContent, Typography, Link } from '@mui/material';
+import { Navigate, Link as RouterLink, useSearchParams } from 'react-router-dom';
+import { Container, Card, CardContent, Typography, Link, Divider, Alert } from '@mui/material';
 import { useAuth } from '../contexts/AuthContext';
 import { LoginForm } from '../components/LoginForm';
+import { GoogleLoginButton } from '../components/GoogleLoginButton';
 
 export function LoginPage() {
   const { user, isLoading } = useAuth();
+  const [searchParams] = useSearchParams();
+  const oauthError = searchParams.get('error');
 
   if (!isLoading && user) {
     return <Navigate to="/" replace />;
@@ -13,12 +16,17 @@ export function LoginPage() {
   return (
     <Container maxWidth="sm" sx={{ mt: 8 }}>
       <Card>
-        <CardContent sx={{ p: 4 }}>
+        <CardContent sx={{ p: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
           <Typography variant="h4" component="h1" gutterBottom textAlign="center">
             Login
           </Typography>
+          {oauthError && (
+            <Alert severity="error">Google login failed. Please try again.</Alert>
+          )}
+          <GoogleLoginButton />
+          <Divider>or</Divider>
           <LoginForm />
-          <Typography variant="body2" textAlign="center" sx={{ mt: 2 }}>
+          <Typography variant="body2" textAlign="center">
             Don't have an account?{' '}
             <Link component={RouterLink} to="/register">Register</Link>
           </Typography>

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -1,7 +1,8 @@
 import { Navigate, Link as RouterLink } from 'react-router-dom';
-import { Container, Card, CardContent, Typography, Link } from '@mui/material';
+import { Container, Card, CardContent, Typography, Link, Divider } from '@mui/material';
 import { useAuth } from '../contexts/AuthContext';
 import { RegisterForm } from '../components/RegisterForm';
+import { GoogleLoginButton } from '../components/GoogleLoginButton';
 
 export function RegisterPage() {
   const { user, isLoading } = useAuth();
@@ -13,12 +14,14 @@ export function RegisterPage() {
   return (
     <Container maxWidth="sm" sx={{ mt: 8 }}>
       <Card>
-        <CardContent sx={{ p: 4 }}>
+        <CardContent sx={{ p: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
           <Typography variant="h4" component="h1" gutterBottom textAlign="center">
             Register
           </Typography>
+          <GoogleLoginButton />
+          <Divider>or</Divider>
           <RegisterForm />
-          <Typography variant="body2" textAlign="center" sx={{ mt: 2 }}>
+          <Typography variant="body2" textAlign="center">
             Already have an account?{' '}
             <Link component={RouterLink} to="/login">Login</Link>
           </Typography>

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,3 +2,7 @@ DATABASE_URL=postgresql://postgres:password@localhost:5432/sports_partner
 PORT=3001
 JWT_SECRET=change-me-to-a-random-secret
 CLIENT_ORIGIN=http://localhost:5173
+
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_CALLBACK_URL=http://localhost:3001/api/auth/google/callback

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,8 @@
         "express": "^4.21.0",
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.1.1",
+        "passport": "^0.7.0",
+        "passport-google-oauth20": "^2.0.0",
         "pg": "^8.20.0",
         "zod": "^4.3.6"
       },
@@ -26,6 +28,8 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/multer": "^2.1.0",
         "@types/node": "^22.19.15",
+        "@types/passport": "^1.0.17",
+        "@types/passport-google-oauth20": "^2.0.17",
         "@types/pg": "^8.18.0",
         "dotenv": "^17.3.1",
         "drizzle-kit": "^0.31.9",
@@ -1011,6 +1015,50 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/oauth": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.6.tgz",
+      "integrity": "sha512-H9TRCVKBNOhZZmyHLqFt9drPM9l+ShWiqqJijU1B8P3DX3ub84NjxDuy+Hjrz+fEca5Kwip3qPMKNyiLgNJtIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/passport": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-google-oauth20": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport-google-oauth20/-/passport-google-oauth20-2.0.17.tgz",
+      "integrity": "sha512-MHNOd2l7gOTCn3iS+wInPQMiukliAUvMpODO3VlXxOiwNEMSyzV7UNvAdqxSN872o8OXx1SqPDVT6tLW74AtqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
+      }
+    },
+    "node_modules/@types/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-6//z+4orIOy/g3zx17HyQ71GSRK4bs7Sb+zFasRoc2xzlv7ZCJ+vkDBYFci8U6HY+or6Zy7ajf4mz4rK7nsWJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/oauth": "*",
+        "@types/passport": "*"
+      }
+    },
     "node_modules/@types/pg": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.18.0.tgz",
@@ -1087,6 +1135,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bcryptjs": {
       "version": "3.0.3",
@@ -2485,6 +2542,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+      "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2523,10 +2586,73 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/pg": {
       "version": "8.20.0",
@@ -2990,6 +3116,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,8 @@
     "express": "^4.21.0",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.1.1",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
     "pg": "^8.20.0",
     "zod": "^4.3.6"
   },
@@ -33,6 +35,8 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^2.1.0",
     "@types/node": "^22.19.15",
+    "@types/passport": "^1.0.17",
+    "@types/passport-google-oauth20": "^2.0.17",
     "@types/pg": "^8.18.0",
     "dotenv": "^17.3.1",
     "drizzle-kit": "^0.31.9",

--- a/server/src/db/migrations/0004_oauth_refresh_tokens.sql
+++ b/server/src/db/migrations/0004_oauth_refresh_tokens.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "refresh_tokens" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"token" varchar(255) NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "refresh_tokens_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "users" ALTER COLUMN "password_hash" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "provider" varchar(50) DEFAULT 'local' NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "provider_id" varchar(255);--> statement-breakpoint
+ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "provider_provider_id_idx" ON "users" USING btree ("provider","provider_id") WHERE "users"."provider" != 'local';

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777100000000,
       "tag": "0003_game_weather",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1777130182435,
+      "tag": "0004_oauth_refresh_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -8,15 +8,36 @@ import {
   timestamp,
   primaryKey,
   real,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core';
-import { relations } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 
-export const users = pgTable('users', {
+export const users = pgTable(
+  'users',
+  {
+    id: serial('id').primaryKey(),
+    name: varchar('name', { length: 100 }).notNull(),
+    email: varchar('email', { length: 255 }).notNull().unique(),
+    profileImageUrl: varchar('profile_image_url', { length: 512 }),
+    passwordHash: varchar('password_hash', { length: 255 }),
+    provider: varchar('provider', { length: 50 }).default('local').notNull(),
+    providerId: varchar('provider_id', { length: 255 }),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('provider_provider_id_idx')
+      .on(table.provider, table.providerId)
+      .where(sql`${table.provider} != 'local'`),
+  ],
+);
+
+export const refreshTokens = pgTable('refresh_tokens', {
   id: serial('id').primaryKey(),
-  name: varchar('name', { length: 100 }).notNull(),
-  email: varchar('email', { length: 255 }).notNull().unique(),
-  profileImageUrl: varchar('profile_image_url', { length: 512 }),
-  passwordHash: varchar('password_hash', { length: 255 }).notNull(),
+  userId: integer('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  token: varchar('token', { length: 255 }).notNull().unique(),
+  expiresAt: timestamp('expires_at').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
 });
 
@@ -100,6 +121,11 @@ export const usersRelations = relations(users, ({ many }) => ({
   participations: many(participants),
   gameLikes: many(gameLikes),
   gameComments: many(gameComments),
+  refreshTokens: many(refreshTokens),
+}));
+
+export const refreshTokensRelations = relations(refreshTokens, ({ one }) => ({
+  user: one(users, { fields: [refreshTokens.userId], references: [users.id] }),
 }));
 
 export const sportsRelations = relations(sports, ({ many }) => ({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,10 +3,12 @@ import express from 'express';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import path from 'node:path';
+import passport from 'passport';
 import { authRouter } from './routes/auth.js';
 import { gamesRouter } from './routes/games.js';
 import { sportsRouter } from './routes/sports.js';
 import { venuesRouter } from './routes/venues.js';
+import { configurePassport } from './lib/passport.js';
 
 const app = express();
 const PORT = process.env.PORT ?? 3001;
@@ -18,6 +20,9 @@ app.use(cors({
 app.use(express.json());
 app.use(cookieParser());
 app.use('/uploads', express.static(path.join(process.cwd(), 'uploads')));
+app.use(passport.initialize());
+
+configurePassport();
 
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });

--- a/server/src/lib/jwt.ts
+++ b/server/src/lib/jwt.ts
@@ -1,5 +1,9 @@
 import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
 import type { CookieOptions } from 'express';
+import { db } from '../db/client.js';
+import { refreshTokens } from '../db/schema.js';
+import { eq, lt } from 'drizzle-orm';
 
 function getJwtSecret(): string {
   const secret = process.env.JWT_SECRET;
@@ -10,8 +14,10 @@ function getJwtSecret(): string {
 }
 
 const JWT_SECRET = getJwtSecret();
-const JWT_EXPIRY = '7d';
-const COOKIE_NAME = 'token';
+const ACCESS_TOKEN_EXPIRY = '15m';
+const REFRESH_TOKEN_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const ACCESS_COOKIE_NAME = 'token';
+const REFRESH_COOKIE_NAME = 'refresh_token';
 
 export interface JwtPayload {
   id: number;
@@ -21,26 +27,96 @@ export interface JwtPayload {
 }
 
 export function signToken(payload: JwtPayload): string {
-  return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRY });
+  return jwt.sign(payload, JWT_SECRET, { expiresIn: ACCESS_TOKEN_EXPIRY });
 }
 
 export function verifyToken(token: string): JwtPayload {
   return jwt.verify(token, JWT_SECRET) as JwtPayload;
 }
 
-export function getCookieOptions(): CookieOptions {
+export async function createRefreshToken(userId: number): Promise<string> {
+  const token = crypto.randomBytes(40).toString('hex');
+  const expiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS);
+
+  await db.insert(refreshTokens).values({ userId, token, expiresAt });
+
+  return token;
+}
+
+export async function rotateRefreshToken(oldToken: string): Promise<{ accessToken: string; refreshToken: string; user: JwtPayload } | null> {
+  const [row] = await db
+    .select()
+    .from(refreshTokens)
+    .where(eq(refreshTokens.token, oldToken))
+    .limit(1);
+
+  if (!row || row.expiresAt < new Date()) {
+    if (row) {
+      await db.delete(refreshTokens).where(eq(refreshTokens.token, oldToken));
+    }
+    return null;
+  }
+
+  // Delete the old token
+  await db.delete(refreshTokens).where(eq(refreshTokens.token, oldToken));
+
+  // Look up the user to build the JWT payload
+  const { users } = await import('../db/schema.js');
+  const [user] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      profileImageUrl: users.profileImageUrl,
+    })
+    .from(users)
+    .where(eq(users.id, row.userId))
+    .limit(1);
+
+  if (!user) return null;
+
+  const payload: JwtPayload = {
+    id: user.id,
+    email: user.email,
+    name: user.name,
+    profileImageUrl: user.profileImageUrl ?? null,
+  };
+  const accessToken = signToken(payload);
+  const refreshToken = await createRefreshToken(user.id);
+
+  return { accessToken, refreshToken, user: payload };
+}
+
+export async function revokeRefreshToken(token: string): Promise<void> {
+  await db.delete(refreshTokens).where(eq(refreshTokens.token, token));
+}
+
+export async function revokeAllUserRefreshTokens(userId: number): Promise<void> {
+  await db.delete(refreshTokens).where(eq(refreshTokens.userId, userId));
+}
+
+export async function cleanExpiredTokens(): Promise<void> {
+  await db.delete(refreshTokens).where(lt(refreshTokens.expiresAt, new Date()));
+}
+
+export function getAccessCookieOptions(): CookieOptions {
   return {
     httpOnly: true,
     sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
-    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+    maxAge: 15 * 60 * 1000, // 15 minutes
     path: '/',
   };
 }
 
-export function getClearCookieOptions(): CookieOptions {
-  const { maxAge: _maxAge, expires: _expires, ...rest } = getCookieOptions();
-  return rest;
+export function getRefreshCookieOptions(): CookieOptions {
+  return {
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: REFRESH_TOKEN_EXPIRY_MS,
+    path: '/api/auth',
+  };
 }
 
-export { COOKIE_NAME };
+export { ACCESS_COOKIE_NAME, REFRESH_COOKIE_NAME };

--- a/server/src/lib/passport.ts
+++ b/server/src/lib/passport.ts
@@ -1,0 +1,83 @@
+import passport from 'passport';
+import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
+import { eq, and } from 'drizzle-orm';
+import { db } from '../db/client.js';
+import { users } from '../db/schema.js';
+
+function getGoogleCredentials() {
+  const clientID = process.env.GOOGLE_CLIENT_ID;
+  const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
+  if (!clientID || !clientSecret) {
+    return null;
+  }
+  return { clientID, clientSecret };
+}
+
+export function configurePassport() {
+  const creds = getGoogleCredentials();
+  if (!creds) {
+    console.warn('GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET not set — Google OAuth disabled');
+    return;
+  }
+
+  const callbackURL = process.env.GOOGLE_CALLBACK_URL ?? 'http://localhost:3001/api/auth/google/callback';
+
+  passport.use(
+    new GoogleStrategy(
+      {
+        clientID: creds.clientID,
+        clientSecret: creds.clientSecret,
+        callbackURL,
+        scope: ['profile', 'email'],
+      },
+      async (_accessToken, _refreshToken, profile, done) => {
+        try {
+          const googleId = profile.id;
+          const email = profile.emails?.[0]?.value;
+          const name = profile.displayName;
+
+          if (!email) {
+            return done(new Error('Google account has no email'));
+          }
+
+          // Check if a user with this Google provider ID already exists
+          const [existingOAuth] = await db
+            .select()
+            .from(users)
+            .where(and(eq(users.provider, 'google'), eq(users.providerId, googleId)))
+            .limit(1);
+
+          if (existingOAuth) {
+            return done(null, existingOAuth);
+          }
+
+          // Check if a user with this email already exists (local account)
+          const [existingEmail] = await db
+            .select()
+            .from(users)
+            .where(eq(users.email, email))
+            .limit(1);
+
+          if (existingEmail) {
+            return done(new Error('An account with this email already exists. Please log in with your password.'));
+          }
+
+          // Create a new user
+          const [newUser] = await db
+            .insert(users)
+            .values({
+              name,
+              email,
+              provider: 'google',
+              providerId: googleId,
+            })
+            .returning();
+
+          return done(null, newUser);
+        } catch (err) {
+          return done(err as Error);
+        }
+      },
+    ),
+  );
+}

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,16 +1,14 @@
 import type { Request, Response, NextFunction } from 'express';
-import { verifyToken, COOKIE_NAME, type JwtPayload } from '../lib/jwt.js';
+import { verifyToken, ACCESS_COOKIE_NAME, type JwtPayload } from '../lib/jwt.js';
 
 declare global {
   namespace Express {
-    interface Request {
-      user?: JwtPayload;
-    }
+    interface User extends JwtPayload {}
   }
 }
 
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  const token = req.cookies?.[COOKIE_NAME];
+  const token = req.cookies?.[ACCESS_COOKIE_NAME];
 
   if (!token) {
     res.status(401).json({ error: 'Not authenticated' });
@@ -27,7 +25,7 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
 }
 
 export function optionalAuth(req: Request, _res: Response, next: NextFunction): void {
-  const token = req.cookies?.[COOKIE_NAME];
+  const token = req.cookies?.[ACCESS_COOKIE_NAME];
   if (!token) {
     next();
     return;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -4,11 +4,23 @@ import path from 'node:path';
 import fs from 'node:fs/promises';
 import crypto from 'node:crypto';
 import multer from 'multer';
+import passport from 'passport';
 import { eq } from 'drizzle-orm';
 import { db } from '../db/client.js';
 import { users } from '../db/schema.js';
-import { signToken, getCookieOptions, getClearCookieOptions, COOKIE_NAME } from '../lib/jwt.js';
+import {
+  signToken,
+  createRefreshToken,
+  rotateRefreshToken,
+  revokeRefreshToken,
+  getAccessCookieOptions,
+  getRefreshCookieOptions,
+  ACCESS_COOKIE_NAME,
+  REFRESH_COOKIE_NAME,
+} from '../lib/jwt.js';
 import { requireAuth } from '../middleware/auth.js';
+
+const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN ?? 'http://localhost:5173';
 
 export const authRouter = Router();
 const uploadsDir = path.join(process.cwd(), 'uploads', 'profiles');
@@ -36,11 +48,15 @@ const upload = multer({
   },
 });
 
+function setAuthCookies(res: Response, accessToken: string, refreshToken: string) {
+  res.cookie(ACCESS_COOKIE_NAME, accessToken, getAccessCookieOptions());
+  res.cookie(REFRESH_COOKIE_NAME, refreshToken, getRefreshCookieOptions());
+}
+
 // POST /api/auth/register
 authRouter.post('/register', async (req: Request, res: Response) => {
   try {
     const { name, email, password } = req.body;
-
 
     if (!name || !email || !password) {
       res.status(400).json({ error: 'This field is required' });
@@ -81,13 +97,14 @@ authRouter.post('/register', async (req: Request, res: Response) => {
         profileImageUrl: users.profileImageUrl,
       });
 
-    const token = signToken({
+    const accessToken = signToken({
       id: newUser.id,
       email: newUser.email,
       name: newUser.name,
       profileImageUrl: newUser.profileImageUrl ?? null,
     });
-    res.cookie(COOKIE_NAME, token, getCookieOptions());
+    const refreshToken = await createRefreshToken(newUser.id);
+    setAuthCookies(res, accessToken, refreshToken);
     res.status(201).json({ user: newUser });
   } catch (err: unknown) {
     if (
@@ -117,7 +134,7 @@ authRouter.post('/login', async (req: Request, res: Response) => {
       .where(eq(users.email, email))
       .limit(1);
 
-    if (!user) {
+    if (!user || !user.passwordHash) {
       res.status(401).json({ error: 'Invalid email or password' });
       return;
     }
@@ -129,13 +146,14 @@ authRouter.post('/login', async (req: Request, res: Response) => {
       return;
     }
 
-    const token = signToken({
+    const accessToken = signToken({
       id: user.id,
       email: user.email,
       name: user.name,
       profileImageUrl: user.profileImageUrl ?? null,
     });
-    res.cookie(COOKIE_NAME, token, getCookieOptions());
+    const refreshToken = await createRefreshToken(user.id);
+    setAuthCookies(res, accessToken, refreshToken);
     res.json({
       user: {
         id: user.id,
@@ -149,11 +167,80 @@ authRouter.post('/login', async (req: Request, res: Response) => {
   }
 });
 
+// POST /api/auth/refresh
+authRouter.post('/refresh', async (req: Request, res: Response) => {
+  try {
+    const oldToken = req.cookies?.[REFRESH_COOKIE_NAME];
+    if (!oldToken) {
+      res.status(401).json({ error: 'No refresh token' });
+      return;
+    }
+
+    const result = await rotateRefreshToken(oldToken);
+    if (!result) {
+      res.clearCookie(REFRESH_COOKIE_NAME, getRefreshCookieOptions());
+      res.status(401).json({ error: 'Invalid refresh token' });
+      return;
+    }
+
+    setAuthCookies(res, result.accessToken, result.refreshToken);
+    res.json({
+      user: {
+        id: result.user.id,
+        name: result.user.name,
+        email: result.user.email,
+        profileImageUrl: result.user.profileImageUrl ?? null,
+      },
+    });
+  } catch {
+    res.status(500).json({ error: 'Server error, please try again later' });
+  }
+});
+
 // POST /api/auth/logout
-authRouter.post('/logout', (_req: Request, res: Response) => {
-  res.clearCookie(COOKIE_NAME, getClearCookieOptions());
+authRouter.post('/logout', async (req: Request, res: Response) => {
+  const refreshToken = req.cookies?.[REFRESH_COOKIE_NAME];
+  if (refreshToken) {
+    await revokeRefreshToken(refreshToken).catch(() => {});
+  }
+  res.clearCookie(ACCESS_COOKIE_NAME, getAccessCookieOptions());
+  res.clearCookie(REFRESH_COOKIE_NAME, getRefreshCookieOptions());
   res.json({ success: true });
 });
+
+// GET /api/auth/google
+authRouter.get(
+  '/google',
+  passport.authenticate('google', { session: false, scope: ['profile', 'email'] }),
+);
+
+// GET /api/auth/google/callback
+authRouter.get(
+  '/google/callback',
+  passport.authenticate('google', {
+    session: false,
+    failureRedirect: `${CLIENT_ORIGIN}/login?error=oauth_failed`,
+  }),
+  async (req: Request, res: Response) => {
+    try {
+      const user = req.user! as { id: number; email: string; name: string; profileImageUrl: string | null | undefined };
+
+      const accessToken = signToken({
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        profileImageUrl: user.profileImageUrl ?? null,
+      });
+      const refreshToken = await createRefreshToken(user.id);
+
+      res.cookie(ACCESS_COOKIE_NAME, accessToken, getAccessCookieOptions());
+      res.cookie(REFRESH_COOKIE_NAME, refreshToken, getRefreshCookieOptions());
+      res.redirect(CLIENT_ORIGIN);
+    } catch {
+      res.redirect(`${CLIENT_ORIGIN}/login?error=oauth_failed`);
+    }
+  },
+);
 
 // GET /api/auth/me
 authRouter.get('/me', requireAuth, (req: Request, res: Response) => {
@@ -221,13 +308,13 @@ authRouter.put('/profile', requireAuth, async (req: Request, res: Response) => {
           profileImageUrl: users.profileImageUrl,
         });
 
-      const token = signToken({
+      const accessToken = signToken({
         id: updatedUser.id,
         email: updatedUser.email,
         name: updatedUser.name,
         profileImageUrl: updatedUser.profileImageUrl ?? null,
       });
-      res.cookie(COOKIE_NAME, token, getCookieOptions());
+      res.cookie(ACCESS_COOKIE_NAME, accessToken, getAccessCookieOptions());
       res.json({ user: updatedUser });
     } catch {
       res.status(500).json({ error: 'Server error, please try again later' });


### PR DESCRIPTION
## Summary
- Integrate Google OAuth login via Passport.js with redirect flow (`/api/auth/google` → Google consent → `/api/auth/google/callback`)
- Add refresh token system: short-lived access tokens (15min) + long-lived refresh tokens (30 days) stored in DB with rotation on use
- Update User model with `provider`, `providerId` columns and nullable `passwordHash` for OAuth users
- Add "Continue with Google" button on login and register pages
- Client-side transparent token refresh on 401 responses

## Changes
- **Server**: New `refreshTokens` table, Passport.js Google strategy, `/api/auth/refresh` endpoint, updated login/register/logout to issue/revoke refresh tokens
- **Client**: `GoogleLoginButton` component, `fetchWithRefresh` wrapper in AuthContext, OAuth error handling on login page
- **Migration**: `0003_oauth_refresh_tokens.sql` — adds `refresh_tokens` table, `provider`/`provider_id` columns to users

## Setup
Set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and optionally `GOOGLE_CALLBACK_URL` in `.env`. Google OAuth is disabled gracefully if credentials are not set.

## Test plan
- [ ] Register/login with email+password still works as before
- [ ] Click "Continue with Google" redirects to Google consent screen
- [ ] After Google consent, user is created and redirected to app authenticated
- [ ] Existing email/password user trying Google login with same email gets rejected
- [ ] Access token expires after 15min, refresh transparently issues new one
- [ ] Logout clears both cookies and revokes refresh token
- [ ] App works normally when Google credentials are not configured (button shows but redirect fails gracefully)

Closes #17